### PR TITLE
Event driven choices

### DIFF
--- a/src/BoltForms.php
+++ b/src/BoltForms.php
@@ -126,7 +126,7 @@ class BoltForms
     public function addField($formName, $fieldName, $type, array $options)
     {
         $em = $this->app['storage'];
-        $fieldOptions = new FieldOptions($formName, $fieldName, $type, $options, $em, $this->app['logger.system']);
+        $fieldOptions = new FieldOptions($formName, $fieldName, $type, $options, $em, $this->app['logger.system'], $this->app['dispatcher']);
 
         $this->getForm($formName)->add($fieldName, $type, $fieldOptions->toArray());
     }

--- a/src/Choice/EventType.php
+++ b/src/Choice/EventType.php
@@ -70,8 +70,7 @@ class EventType implements ChoiceInterface
     public function getChoices()
     {
         if ($this->choices === null) {
-            $choices = new ParameterBag();
-            $event = new BoltFormsChoiceEvent($choices);
+            $event = new BoltFormsChoiceEvent($this->name, $this->options);
 
             $this->dispatcher->dispatch(BoltFormsEvents::DATA_CHOICE_EVENT, $event);
 

--- a/src/Choice/EventType.php
+++ b/src/Choice/EventType.php
@@ -72,11 +72,23 @@ class EventType implements ChoiceInterface
         if ($this->choices === null) {
             $event = new BoltFormsChoiceEvent($this->name, $this->options);
 
-            $this->dispatcher->dispatch(BoltFormsEvents::DATA_CHOICE_EVENT, $event);
+            $this->dispatcher->dispatch($this->getEventName(), $event);
 
             $this->choices = $event->getChoices();
         }
 
         return $this->choices;
+    }
+
+    /**
+     * Return the name of the event we want to dispatch.
+     * 
+     * @return string
+     */
+    private function getEventName()
+    {
+        $parts = explode('::', $this->options['choices']);
+
+        return isset($parts[1]) ? $parts[1] : BoltFormsEvents::DATA_CHOICE_EVENT;
     }
 }

--- a/src/Choice/EventType.php
+++ b/src/Choice/EventType.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace Bolt\Extension\Bolt\BoltForms\Choice;
+
+use Bolt\Extension\Bolt\BoltForms\Event\BoltFormsChoiceEvent;
+use Bolt\Extension\Bolt\BoltForms\Event\BoltFormsEvents;
+use Symfony\Component\HttpFoundation\ParameterBag;
+use Symfony\Component\HttpKernel\Debug\TraceableEventDispatcher;
+
+/**
+ * Event driven choices for BoltForms.
+ *
+ * Copyright (c) 2014-2016 Gawain Lynch
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * @author    Gawain Lynch <gawain.lynch@gmail.com>
+ * @copyright Copyright (c) 2014-2016, Gawain Lynch
+ * @license   http://opensource.org/licenses/GPL-3.0 GNU Public License 3.0
+ */
+class EventType implements ChoiceInterface
+{
+    /** @var  TraceableEventDispatcher */
+    private $dispatcher;
+    /** @var string */
+    private $name;
+    /** @var array */
+    private $options;
+    /** @var array */
+    private $choices;
+
+    /**
+     * @param TraceableEventDispatcher $dispatcher
+     * @param string                   $name    Name of the BoltForms field
+     * @param array                    $options
+     */
+    public function __construct(TraceableEventDispatcher $dispatcher, $name, array $options)
+    {
+        $this->dispatcher = $dispatcher;
+        $this->name = $name;
+        $this->options = $options;
+    }
+
+    /**
+     * Get the name.
+     *
+     * @return string
+     */
+    public function getName()
+    {
+        return $this->name;
+    }
+
+    /**
+     * Return choices array.
+     *
+     * @return array
+     */
+    public function getChoices()
+    {
+        if ($this->choices === null) {
+            $choices = new ParameterBag();
+            $event = new BoltFormsChoiceEvent($choices);
+
+            $this->dispatcher->dispatch(BoltFormsEvents::DATA_CHOICE_EVENT, $event);
+
+            $this->choices = $event->getChoices();
+        }
+
+        return $this->choices;
+    }
+}

--- a/src/Event/BoltFormsChoiceEvent.php
+++ b/src/Event/BoltFormsChoiceEvent.php
@@ -29,17 +29,40 @@ use Symfony\Component\HttpFoundation\ParameterBag;
  */
 class BoltFormsChoiceEvent extends Event
 {
+    /** @var string */
+    private $name;
+    /** @var array */
+    private $options;
     /** @var ParameterBag */
     private $choices;
 
     /**
      * Constructor.
      *
-     * @param ParameterBag $choices
+     * @param string $name
+     * @param array  $options
      */
-    public function __construct(ParameterBag $choices)
+    public function __construct($name, array $options)
     {
-        $this->choices = $choices;
+        $this->name = $name;
+        $this->options = $options;
+        $this->choices = new ParameterBag();
+    }
+
+    /**
+     * @return string
+     */
+    public function getName()
+    {
+        return $this->name;
+    }
+
+    /**
+     * @return array
+     */
+    public function getOptions()
+    {
+        return $this->options;
     }
 
     /**

--- a/src/Event/BoltFormsChoiceEvent.php
+++ b/src/Event/BoltFormsChoiceEvent.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace Bolt\Extension\Bolt\BoltForms\Event;
+
+use Symfony\Component\EventDispatcher\Event;
+use Symfony\Component\HttpFoundation\ParameterBag;
+
+/**
+ * Event to generate event choices for BoltForms.
+ *
+ * Copyright (c) 2014-2016 Gawain Lynch
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * @author    Gawain Lynch <gawain.lynch@gmail.com>
+ * @copyright Copyright (c) 2014-2016, Gawain Lynch
+ * @license   http://opensource.org/licenses/GPL-3.0 GNU Public License 3.0
+ */
+class BoltFormsChoiceEvent extends Event
+{
+    /** @var ParameterBag */
+    private $choices;
+
+    /**
+     * Constructor.
+     *
+     * @param ParameterBag $choices
+     */
+    public function __construct(ParameterBag $choices)
+    {
+        $this->choices = $choices;
+    }
+
+    /**
+     * @return mixed $key
+     */
+    public function getChoice($key)
+    {
+        return $this->choices->get($key);
+    }
+
+    /**
+     * @return array
+     */
+    public function getChoices()
+    {
+        return $this->choices->all();
+    }
+
+    /**
+     * @param string $key
+     * @param mixed  $value
+     */
+    public function setChoice($key, $value)
+    {
+        $this->choices->set($key, $value);
+    }
+
+    /**
+     * @param array $choices
+     */
+    public function setChoices(array $choices)
+    {
+        $this->choices = new ParameterBag($choices);
+    }
+}

--- a/src/Event/BoltFormsEvents.php
+++ b/src/Event/BoltFormsEvents.php
@@ -57,6 +57,8 @@ final class BoltFormsEvents
     const DATA_SESSION_VALUE = 'boltforms.session_value';
     const DATA_TIMESTAMP = 'boltforms.timestamp';
 
+    const DATA_CHOICE_EVENT = 'boltforms.choice';
+
     /*
      * Email notification
      */

--- a/src/FieldOptions.php
+++ b/src/FieldOptions.php
@@ -4,8 +4,10 @@ namespace Bolt\Extension\Bolt\BoltForms;
 
 use Bolt\Extension\Bolt\BoltForms\Choice\ArrayType;
 use Bolt\Extension\Bolt\BoltForms\Choice\ContentType;
+use Bolt\Extension\Bolt\BoltForms\Choice\EventType;
 use Bolt\Storage\EntityManager;
 use Psr\Log\LoggerInterface;
+use Symfony\Component\HttpKernel\Debug\TraceableEventDispatcher;
 
 /**
  * Choices options for BoltForms
@@ -32,9 +34,9 @@ use Psr\Log\LoggerInterface;
 class FieldOptions
 {
     /** @var string */
-    private $formname;
+    private $formName;
     /** @var string */
-    private $fieldname;
+    private $fieldName;
     /** @var string */
     private $type;
     /** @var array */
@@ -47,25 +49,29 @@ class FieldOptions
     private $logger;
     /** @var boolean */
     private $initialised;
+    /** @var TraceableEventDispatcher */
+    private $dispatcher;
 
     /**
      * Constructor.
      *
-     * @param string          $formname
-     * @param string          $fieldname
-     * @param string          $type
-     * @param array           $baseOptions
-     * @param EntityManager   $storage
-     * @param LoggerInterface $logger
+     * @param string                   $formName
+     * @param string                   $fieldName
+     * @param string                   $type
+     * @param array                    $baseOptions
+     * @param EntityManager            $storage
+     * @param LoggerInterface          $logger
+     * @param TraceableEventDispatcher $dispatcher
      */
-    public function __construct($formname, $fieldname, $type, array $baseOptions, EntityManager $storage, LoggerInterface $logger)
+    public function __construct($formName, $fieldName, $type, array $baseOptions, EntityManager $storage, LoggerInterface $logger, TraceableEventDispatcher $dispatcher)
     {
-        $this->formname = $formname;
-        $this->fieldname = $fieldname;
+        $this->formName = $formName;
+        $this->fieldName = $fieldName;
         $this->type = $type;
         $this->baseOptions = $baseOptions;
         $this->em = $storage;
         $this->logger = $logger;
+        $this->dispatcher = $dispatcher;
     }
 
     /**
@@ -120,14 +126,16 @@ class FieldOptions
     protected function getChoiceValues(array &$options)
     {
         if (is_string($this->baseOptions['choices']) && strpos($this->baseOptions['choices'], 'contenttype::') === 0) {
-            $choice = new ContentType($this->em, $this->fieldname, $this->baseOptions);
+            $choice = new ContentType($this->em, $this->fieldName, $this->baseOptions);
 
             // Only unset for a this type as it's custom
             unset($options['sort']);
             unset($options['limit']);
             unset($options['filters']);
+        } elseif (is_string($this->baseOptions['choices']) && strpos($this->baseOptions['choices'], 'event::') === 0) {
+            $choice = new EventType($this->dispatcher, $this->fieldName, $this->baseOptions);
         } else {
-            $choice = new ArrayType($this->fieldname, $this->baseOptions['choices']);
+            $choice = new ArrayType($this->fieldName, $this->baseOptions['choices']);
         }
 
         return $choice->getChoices();
@@ -143,10 +151,10 @@ class FieldOptions
         }
 
         if (gettype($this->baseOptions['constraints']) === 'string') {
-            $this->options['constraints'] = $this->getConstraintObject($this->formname, $this->baseOptions['constraints']);
+            $this->options['constraints'] = $this->getConstraintObject($this->formName, $this->baseOptions['constraints']);
         } else {
             foreach ($this->baseOptions['constraints'] as $key => $constraint) {
-                $this->options['constraints'][$key] = $this->getConstraintObject($this->formname, [$key => $constraint]);
+                $this->options['constraints'][$key] = $this->getConstraintObject($this->formName, [$key => $constraint]);
             }
         }
     }

--- a/src/FieldOptions.php
+++ b/src/FieldOptions.php
@@ -132,7 +132,7 @@ class FieldOptions
             unset($options['sort']);
             unset($options['limit']);
             unset($options['filters']);
-        } elseif (is_string($this->baseOptions['choices']) && strpos($this->baseOptions['choices'], 'event::') === 0) {
+        } elseif (is_string($this->baseOptions['choices']) && strpos($this->baseOptions['choices'], 'event') === 0) {
             $choice = new EventType($this->dispatcher, $this->fieldName, $this->baseOptions);
         } else {
             $choice = new ArrayType($this->fieldName, $this->baseOptions['choices']);


### PR DESCRIPTION

This allows site designers to choose fields of `choice` type that get their select data from events

```yaml
    needreply:
      type: choice
      options:
        required: false
        label: Do you need us to contact you back?
        choices: event
        multiple: false
    wantreply:
      type: choice
      options:
        required: false
        label: Do you want us to contact you back?
        choices: event::your.custom.wants
        multiple: false
```

```php
    protected function subscribe(EventDispatcherInterface $dispatcher)
    {
        $dispatcher->addListener(BoltFormsEvents::DATA_CHOICE_EVENT, [$this, 'replyChoices']);
        $dispatcher->addListener('your.custom.wants', [$this, 'wantChoices']);
    }

    public function replyChoices(BoltFormsChoiceEvent $event)
    {
        $event->setChoices(['yes' => 'Yes of course', 'no' => 'No way!']);
    }

    public function wantChoices(BoltFormsChoiceEvent $event)
    {
        $event->setChoices(['yes' => 'YSure', 'no' => 'Not in this life']);
    }
```
