### PR TITLE
[docs] add note and change formatting

### DIFF
--- a/doc/fields.md
+++ b/doc/fields.md
@@ -78,6 +78,7 @@ record lookups & event based lookups.
               choices: event::my.custom.event
 ```
 
+**Note:** If you use the `array_assoc` style, the choices are inverted compared to the select fields in Bolt contenttypes.
 
 For more information on this field type, see the [choice fields documentation](fields/choice.md)
 

--- a/doc/fields.md
+++ b/doc/fields.md
@@ -102,15 +102,11 @@ Secondly, is the "filename_handling" parameter. If an attacker knows the
 uploaded file name, this can make their job a bit easier. So we provide three
 options, e.g. uploading the file kitten.jpg:
 
-```
--------------------------------------
-| Setting | Resulting file name     |
-|-----------------------------------|
-| prefix  | kitten.Ze1d352rrI3p.jpg |
-| suffix  | kitten.jpg.Ze1d352rrI3p |
-| keep    | kitten.jpg              |
--------------------------------------
-```
+| Setting   | Resulting file name     |
+|-----------|-------------------------|
+| `prefix`  | kitten.Ze1d352rrI3p.jpg |
+| `suffix`  | kitten.jpg.Ze1d352rrI3p |
+| `keep`    | kitten.jpg              |
 
 We recommend "suffix" as this is the most secure, alternatively "prefix" will
 aid in file browsing. However "keep" should always be used with caution!

--- a/doc/fields.md
+++ b/doc/fields.md
@@ -149,7 +149,7 @@ Use the option `label: false` to hide the field from the html output.
 
 ### Hidden Field Data Providers
 
-**NOTE:** These filed values are set upon successful submission of the form, not during render!
+**Note:** These filed values are set upon successful submission of the form, not during render!
 
 BoltForms allows you to specify, and customise, certain input data upon form
 submission. 

--- a/doc/fields.md
+++ b/doc/fields.md
@@ -101,6 +101,7 @@ Secondly, is the "filename_handling" parameter. If an attacker knows the
 uploaded file name, this can make their job a bit easier. So we provide three
 options, e.g. uploading the file kitten.jpg:
 
+```
 -------------------------------------
 | Setting | Resulting file name     |
 |-----------------------------------|
@@ -108,6 +109,7 @@ options, e.g. uploading the file kitten.jpg:
 | suffix  | kitten.jpg.Ze1d352rrI3p |
 | keep    | kitten.jpg              |
 -------------------------------------
+```
 
 We recommend "suffix" as this is the most secure, alternatively "prefix" will
 aid in file browsing. However "keep" should always be used with caution!

--- a/doc/fields/choice.md
+++ b/doc/fields/choice.md
@@ -5,14 +5,14 @@ Choice Fields
 Simple Choice Selection
 -----------------------
 
-```
+```yaml
     choice_simple:
         type: choice
         options:
             label: A very simple choice
             choices: { 'Item One': 'item_1', 'Item Two': 'item_2' }
 ```
-```
+```yaml
     group_simple:
         type: choice
         options:
@@ -67,7 +67,7 @@ To use ContentType records for choice data, you need to specify a `params:` key 
 
 Other parameters are optional.
 
-```
+```yaml
     contenttype_choice:
         type: choice
         options:
@@ -92,7 +92,7 @@ PHP Class Choices
 Choice data can be supplied via PHP objects. Examples of these object classes
 can be seen [in the examples directory](../example/Choice)
 
-```
+```yaml
     choice_traversable_choices_class:
         type: choice
         options:
@@ -102,7 +102,7 @@ can be seen [in the examples directory](../example/Choice)
             choice_label: Example\StaticChoice::choiceLabel
 ```
 
-```
+```yaml
     choice_static_choices_class:
         type: choice
         options:
@@ -112,7 +112,7 @@ can be seen [in the examples directory](../example/Choice)
             choice_label: Example\StaticChoice::choiceLabel
 ```
 
-```
+```yaml
     choice_with_attrib:
         type: choice
         options:
@@ -122,7 +122,8 @@ can be seen [in the examples directory](../example/Choice)
             choice_label: Example\StaticChoice::choiceLabel
             choice_attr: Example\StaticChoice::choiceAttr
 ```
-```
+
+```yaml
     choice_group_callouts:
         type: choice
         options:
@@ -133,7 +134,7 @@ can be seen [in the examples directory](../example/Choice)
             group_by: Example\StaticChoice::groupBy
 ```
 
-```
+```yaml
     choice_group_callouts_preferred_choices:
         type: choice
         options:
@@ -145,7 +146,7 @@ can be seen [in the examples directory](../example/Choice)
             multiple: false
 ```
 
-```
+```yaml
     choice_group_callouts_preferred_choices:
         type: choice
         options:

--- a/doc/getting-started.md
+++ b/doc/getting-started.md
@@ -8,7 +8,7 @@ You can safely remove, or comment out, this form if you don't need
 it. But it is a handy first place to look, this file will be located at
 `app/config/extensions/boltforms.bolt.yml`.
 
-**NOTE:**
+**Note:**
 When first installed, BoltForms defaults to turning debugging on in the
 configuration.  This should be turned off when deployed in production.
 
@@ -29,7 +29,7 @@ email addresses, the minimum list shown below.
 Then we define two fields; a `comment` field that allows text entry, and
 the `submit` button.
 
-```
+```yaml
 anonymous-comments:
     notification:
         enabled: true

--- a/doc/meta-data.md
+++ b/doc/meta-data.md
@@ -12,7 +12,7 @@ and a set of value keys:
 
 An example would be:
 
-```
+```twig
 {{ boltforms('my_form', 
     meta = {
         'name': {


### PR DESCRIPTION
adds a note about the order of option values compared to contenttypes
add syntax highlights for yml and twig if they were missing