### PR TITLE
Add support for action overriding

### DIFF
--- a/doc/templates.md
+++ b/doc/templates.md
@@ -119,6 +119,15 @@ Or using template names:
     {{ boltforms('form_name', htmlPreSubmit = 'my_pre_template.twig', htmlPostSubmit = 'my_post_template.twig') }}  
 ```
 
+Overriding the Default Form Action
+----------------------------------
+
+By default the form action will point to the current request URL. Occasionally you
+may want to provide your own form action, to do so, just pass in an action variable:
+
+```twig
+   {{ boltforms('form_name', action = '/my/form/handler' }}
+```
 
 Templates for Custom Displays
 -----------------------------

--- a/src/Twig/Extension/BoltFormsRuntime.php
+++ b/src/Twig/Extension/BoltFormsRuntime.php
@@ -118,17 +118,18 @@ class BoltFormsRuntime
      * Twig function for form generation.
      *
      * @param Twig_Environment $twig
-     * @param string $formName Name of the BoltForm to render
-     * @param string $htmlPreSubmit HTML or template name to display BEFORE submit
-     * @param string $htmlPostSubmit HTML or template name to display AFTER successful submit
-     * @param array $data Data array passed to Symfony Forms
-     * @param array $options Options array passed to Symfony Forms
-     * @param array $defaults Default field values
-     * @param array $override Array of form parameters / fields to override settings for
-     * @param mixed $meta Meta data that is not transmitted with the form
-     * @param string|null $action
+     * @param string           $formName       Name of the BoltForm to render
+     * @param string           $htmlPreSubmit  HTML or template name to display BEFORE submit
+     * @param string           $htmlPostSubmit HTML or template name to display AFTER successful submit
+     * @param array            $data           Data array passed to Symfony Forms
+     * @param array            $options        Options array passed to Symfony Forms
+     * @param array            $defaults       Default field values
+     * @param array            $override       Array of form parameters / fields to override settings for
+     * @param mixed            $meta           Meta data that is not transmitted with the form
+     * @param string           $action
      *
      * @return Twig_Markup
+     * @throws \Exception
      */
     public function twigBoltForms(
         Twig_Environment $twig,

--- a/src/Twig/Extension/BoltFormsRuntime.php
+++ b/src/Twig/Extension/BoltFormsRuntime.php
@@ -118,14 +118,15 @@ class BoltFormsRuntime
      * Twig function for form generation.
      *
      * @param Twig_Environment $twig
-     * @param string           $formName       Name of the BoltForm to render
-     * @param string           $htmlPreSubmit  HTML or template name to display BEFORE submit
-     * @param string           $htmlPostSubmit HTML or template name to display AFTER successful submit
-     * @param array            $data           Data array passed to Symfony Forms
-     * @param array            $options        Options array passed to Symfony Forms
-     * @param array            $defaults       Default field values
-     * @param array            $override       Array of form parameters / fields to override settings for
-     * @param mixed            $meta           Meta data that is not transmitted with the form
+     * @param string $formName Name of the BoltForm to render
+     * @param string $htmlPreSubmit HTML or template name to display BEFORE submit
+     * @param string $htmlPostSubmit HTML or template name to display AFTER successful submit
+     * @param array $data Data array passed to Symfony Forms
+     * @param array $options Options array passed to Symfony Forms
+     * @param array $defaults Default field values
+     * @param array $override Array of form parameters / fields to override settings for
+     * @param mixed $meta Meta data that is not transmitted with the form
+     * @param string|null $action
      *
      * @return Twig_Markup
      */
@@ -138,7 +139,8 @@ class BoltFormsRuntime
         $options = [],
         $defaults = null,
         $override = null,
-        $meta = null
+        $meta = null,
+        $action = null
     ) {
         if (!$this->config->getBaseForms()->has($formName)) {
             return new Twig_Markup(
@@ -187,7 +189,7 @@ class BoltFormsRuntime
         $loadAjax = $formConfig->getSubmission()->isAjax();
 
         $formContext
-            ->setAction($this->getRelevantAction($formName, $loadAjax))
+            ->setAction($this->getRelevantAction($formName, $loadAjax, $action))
             ->setHtmlPreSubmit($this->getOptionalHtml($twig, $htmlPreSubmit))
             ->setHtmlPostSubmit($this->getOptionalHtml($twig, $htmlPostSubmit))
             ->setReCaptchaResponse($reCaptchaResponse)
@@ -347,14 +349,19 @@ class BoltFormsRuntime
      * Determine the form 'action' to be used.
      *
      * @param string $formName
-     * @param bool   $loadAjax
+     * @param bool $loadAjax
+     * @param $action
      *
      * @return string
      */
-    protected function getRelevantAction($formName, $loadAjax)
+    protected function getRelevantAction($formName, $loadAjax, $action = null)
     {
         if ($loadAjax) {
             return $this->urlGenerator->generate('boltFormsAsyncSubmit', ['form' => $formName]);
+        }
+
+        if ($action !== null) {
+            return $action;
         }
 
         return $this->requestStack->getCurrentRequest()->getRequestUri();


### PR DESCRIPTION
As described in docs, allows passing an `action` variable into the `boltforms` template tag to allow overriding of the default behaviour.