### PR TITLE
Symfony Forms 3 / Bolt 4 Compatibility — An unfinished Symphony

### DIFF
--- a/src/BoltForms.php
+++ b/src/BoltForms.php
@@ -118,7 +118,7 @@ class BoltForms
         /** @var Config\FormConfig $formConfig */
         $formConfig = $this->config->getForm($formName);
         foreach ($formConfig->getFields()->all() as $key => $field) {
-            $builder->add($key, $field['type'], $field['options']);
+            $builder->add($key, $this->getTypeClassName($field['type']), $field['options']);
         }
 
         /** @var Form $form */
@@ -132,6 +132,23 @@ class BoltForms
         }
 
         return $this->forms[$formName];
+    }
+
+    /**
+     * Return the FQCN of the Symfony Form type, or just the string if not found.
+     *
+     * @param string $type
+     *
+     * @return string
+     */
+    private function getTypeClassName($type)
+    {
+        $className = 'Symfony\\Component\\Form\\Extension\\Core\\Type\\' . ucwords($type) . 'Type';
+        if (class_exists($className)) {
+            return $className;
+        }
+
+        return $type;
     }
 
     /**

--- a/src/Provider/BoltFormsServiceProvider.php
+++ b/src/Provider/BoltFormsServiceProvider.php
@@ -142,6 +142,11 @@ class BoltFormsServiceProvider implements ServiceProviderInterface
         }
 
         $app['twig.runtime.boltforms'] = function ($app) {
+            $rootPath = version_compare(BoltVersion::forComposer(), '3.3.0', '<')
+                ? $app['resources']->getPath('root')
+                : $app['path_resolver']->resolve('%root%')
+            ;
+
             return new Twig\Extension\BoltFormsRuntime(
                 $app['boltforms'],
                 $app['boltforms.config'],
@@ -153,7 +158,7 @@ class BoltFormsServiceProvider implements ServiceProviderInterface
                 $app['logger.system'],
                 $app['url_generator'],
                 $app['extensions']->get('bolt/boltforms')->getWebDirectory()->getPath(),
-                $app['resources']->getPath('root')
+                $rootPath
             );
         };
 


### PR DESCRIPTION
This was a massive TODO on my list when I fell over earlier in the year … Better late than never :wink: 

Short version:
  * Symfony Forms 3+ requires FQCN for all things, this is Part  I that covers off most use-cases
  * Bolt 3.3 deprecates `ResourceManager`, so handle FC & BC

I'd suggest a 4.0-beta3 soon-ish too, as the changes since beta2 are small but inclusive of this will reduce some noise when building Bolt 3.3+ sites :smile: 

![bitter sweet symphony](https://user-images.githubusercontent.com/1427081/28274485-566f7f1e-6b11-11e7-94c4-cd300799b7ab.jpg)