### PR TITLE
Save form compiler to session for ajax forms

### DIFF
--- a/src/Twig/Extension/BoltFormsRuntime.php
+++ b/src/Twig/Extension/BoltFormsRuntime.php
@@ -198,7 +198,7 @@ class BoltFormsRuntime
         ;
 
         // Save to session for AJAX requests
-        if ($this->requestStack->getCurrentRequest()->isXmlHttpRequest()) {
+        if ($loadAjax) {
             $this->session->set('boltforms_compiler_' . $formName, $formContext);
         }
 


### PR DESCRIPTION
From what I can tell this is the only place the form compiler might be save to session ready for the async handler. Checking on the current request being XmlHttp seems like it's not intended, but checking the current form config would make sense.