### PR TITLE
[Feature] Allow disabling Recaptcha on individual forms

### DIFF
--- a/config/config.yml.dist
+++ b/config/config.yml.dist
@@ -193,6 +193,7 @@ contact:
 #        table: bolt_secret_table    # Specific database table to write to
 #    uploads:
 #        subdirectory: showcase_files # The (optional) subdirectory for uploaded files
+#    recaptcha: false    # This setting is optional to use the overall default, false is the only valid value to disable for this form only.
 #    fields:
 #        subject:
 #            type: text

--- a/src/Config/FormConfig.php
+++ b/src/Config/FormConfig.php
@@ -240,7 +240,7 @@ class FormConfig
         foreach ($array2 as $key => &$value) {
             if (is_array($value) && isset($merged[$key]) && is_array($merged[$key])) {
                 $merged[$key] = self::mergeRecursiveDistinct($merged[$key], $value);
-            } elseif (!empty($value)) {
+            } elseif (!empty($value) || $value == false) {
                 $merged[$key] = $value;
             }
         }

--- a/src/Config/FormConfig.php
+++ b/src/Config/FormConfig.php
@@ -43,6 +43,8 @@ class FormConfig
     protected $templates;
     /** @var Form\UploadsOptionsBag */
     protected $uploads;
+    /** @var string */
+    protected $formRecaptcha;
 
     /** @var Config */
     private $rootConfig;
@@ -69,6 +71,7 @@ class FormConfig
         $this->submission   = new Form\SubmissionOptionsBag($formConfig['submission']);
         $this->templates    = new Form\TemplateOptionsBag($formConfig['templates'], $rootConfig);
         $this->uploads      = new Form\UploadsOptionsBag($formConfig['uploads']);
+        $this->formRecaptcha = $formConfig['recaptcha'] == false ? false : true;
     }
 
     /**
@@ -160,6 +163,17 @@ class FormConfig
     }
 
     /**
+     * Get form recaptcha status.
+     *
+     * @return bool
+     */
+    public function getRecaptcha()
+    {
+        return $this->formRecaptcha;
+    }
+
+
+    /**
      * A set of default keys for a form's config.
      *
      * @return array
@@ -207,6 +221,7 @@ class FormConfig
                 'subdirectory' => null,
             ],
             'fields' => [],
+            'recaptcha' => false,
         ];
     }
 

--- a/src/Config/FormConfig.php
+++ b/src/Config/FormConfig.php
@@ -221,7 +221,7 @@ class FormConfig
                 'subdirectory' => null,
             ],
             'fields' => [],
-            'recaptcha' => false,
+            'recaptcha' => true,
         ];
     }
 

--- a/src/Factory/FormContext.php
+++ b/src/Factory/FormContext.php
@@ -92,7 +92,7 @@ class FormContext
             'result'    => $this->result ?: new Result(),
             'templates' => $config->getForm($formName)->getTemplates(),
             'recaptcha' => [
-                'enabled'       => $reCaptchaConfig->isEnabled(),
+                'enabled'       => $reCaptchaConfig->isEnabled() && $config->getForm($formName)->getReCaptcha() !== false,
                 'label'         => $reCaptchaConfig->getLabel(),
                 'public_key'    => $reCaptchaConfig->getPublicKey(),
                 'theme'         => $reCaptchaConfig->getTheme(),

--- a/src/Provider/RecaptchaServiceProvider.php
+++ b/src/Provider/RecaptchaServiceProvider.php
@@ -47,12 +47,12 @@ class RecaptchaServiceProvider implements ServiceProviderInterface
         );
 
         $app['recapture.response.factory'] = $app->protect(
-            function () use ($app) {
+            function ($enabled = true) use ($app) {
                 $request = $app['request_stack']->getCurrentRequest();
                 $config = $app['boltforms.config'];
 
                 // Check reCaptcha, if enabled.  If not just return true
-                if (!$request->isMethod(Request::METHOD_POST) || !$config->getReCaptcha()->isEnabled()) {
+                if (!$request->isMethod(Request::METHOD_POST) || !$config->getReCaptcha()->isEnabled() || $enabled === false) {
                     return [
                         'success'    => true,
                         'errorCodes' => null,

--- a/src/Twig/Extension/BoltFormsRuntime.php
+++ b/src/Twig/Extension/BoltFormsRuntime.php
@@ -180,7 +180,7 @@ class BoltFormsRuntime
 
         // Handle the POST
         $factory = $this->recaptureResponseFactory;
-        $reCaptchaResponse = $factory();
+        $reCaptchaResponse = $factory($formConfig->getRecaptcha());
         try {
             $this->handleFormRequest($formConfig, $formContext, $reCaptchaResponse);
         } catch (HttpException $e) {


### PR DESCRIPTION
Fixes #149 

Allows a setting of `recaptcha: false` on an individual form config to override the global default.