### PR TITLE
Fix use original filename for email attachments

### DIFF
--- a/src/Submission/Handler/Email.php
+++ b/src/Submission/Handler/Email.php
@@ -286,7 +286,7 @@ class Email extends AbstractHandler
     private function attachFile(File $uploadedFile)
     {
         $fromPath = $uploadedFile->getPathname();
-        $fileName = $uploadedFile->getBasename();
+        $fileName = $uploadedFile->getClientOriginalName();
         $attachment = \Swift_Attachment::fromPath($fromPath)->setFilename($fileName);
         $this->getEmailMessage()->attach($attachment);
     }


### PR DESCRIPTION
Using the php tmp name meant the mime guessing wasn't working too.