### PR TITLE
Use an isset check on the entity

### DIFF
--- a/src/Submission/Handler/DatabaseTable.php
+++ b/src/Submission/Handler/DatabaseTable.php
@@ -61,7 +61,7 @@ class DatabaseTable extends AbstractHandler
             // Only attempt to insert fields with existing data this way you can
             // have fields in your table that are not in the form eg. an auto
             // increment id field of a field to track status of a submission
-            if ($formData->has($colName)) {
+            if (isset($formData[$colName])) {
                 $saveData[$colName] = $formData->get($colName, null, true);
             }
 


### PR DESCRIPTION
Fixes #173 

Has check always fails because entities don't necessarily implement the has method... they should all implement ArrayAccess though so an isset check works better.