### PR TITLE
Show the wrong option name in the exception

### DIFF
--- a/src/Config/Form/FieldOptionsBag.php
+++ b/src/Config/Form/FieldOptionsBag.php
@@ -89,6 +89,6 @@ class FieldOptionsBag extends ParameterBag
             return $this->parameters[$name];
         }
 
-        throw new \BadMethodCallException(sprintf('%s ', __CLASS__));
+        throw new \BadMethodCallException(sprintf('Unknown field option parameter: %s ', $name));
     }
 }


### PR DESCRIPTION
This shows the misspelled or non-existing paramater name when throwing the exception.