### PR TITLE
Fix incorrect substitution on dynamic email config

### DIFF
--- a/src/Config/EmailConfig.php
+++ b/src/Config/EmailConfig.php
@@ -317,8 +317,11 @@ class EmailConfig extends ParameterBag
 
         foreach ($hashMap as $internalName => $keyName) {
             $value = $this->getConfigValue($formData, $notifyConfig->get($keyName));
-
-            $this->set($internalName, $value);
+            if ($value === null) {
+                $this->set($internalName, $notifyConfig->get($keyName));
+            } else {
+                $this->set($internalName, $value);
+            }
         }
     }
 

--- a/src/Config/EmailConfig.php
+++ b/src/Config/EmailConfig.php
@@ -316,11 +316,8 @@ class EmailConfig extends ParameterBag
         ];
 
         foreach ($hashMap as $internalName => $keyName) {
-            $configValue = $this->getConfigValue($formData, $notifyConfig->get($keyName));
-            $value = $formData->get($configValue);
-            if ($value === null) {
-                $value = $notifyConfig->get($keyName);
-            }
+            $value = $this->getConfigValue($formData, $notifyConfig->get($keyName));
+
             $this->set($internalName, $value);
         }
     }


### PR DESCRIPTION
Fixes #182 

This correctly looks up the dynamic email value before falling back to a string version if the form value does not exist.