### PR TITLE
Allow for both `replyto_email: email` as well as `from_name: [name, lastname]`

### DIFF
--- a/src/Config/EmailConfig.php
+++ b/src/Config/EmailConfig.php
@@ -316,9 +316,21 @@ class EmailConfig extends ParameterBag
         ];
 
         foreach ($hashMap as $internalName => $keyName) {
-            $value = $this->getConfigValue($formData, $notifyConfig->get($keyName));
+            $key = $notifyConfig->get($keyName);
+
+            // Allow for both `replyto_email: email` as well as `from_name: [name, lastname]`
+            if (is_array($key)) {
+                $value = [];
+                foreach($key as $keyPart) {
+                    $value[] = $this->getConfigValue($formData, $keyPart);
+                }
+                $value = implode(" ", $value);
+            } else {
+                $value = $this->getConfigValue($formData, $key);
+            }
+
             if ($value === null) {
-                $this->set($internalName, $notifyConfig->get($keyName));
+                $this->set($internalName, $key);
             } else {
                 $this->set($internalName, $value);
             }


### PR DESCRIPTION
The documentation mentions this possibility.. It seems like this is a regression in the latest refactoring.  

```yaml
my_form:
    notification:
        from_name: [ first_name, last_name ]
        from_email: email_address
```

This PR restores that. Fixes #203.