### PR TITLE
Make `options` in form configuration optional

### DIFF
--- a/src/BoltForms.php
+++ b/src/BoltForms.php
@@ -305,7 +305,10 @@ class BoltForms
 
         foreach ($formConfig['fields'] as $fieldName => $data) {
             $this->config->assetValidField($formName, $fieldName, $data);
-            $formConfig['fields'][$fieldName]['options'] = $resolverFactory($data['type'], (array) $data['options']);
+            $formConfig['fields'][$fieldName]['options'] = $resolverFactory(
+                $data['type'],
+                isset($data['options']) ? (array) $data['options'] : []
+            );
         }
 
         $resolvedFormConfig = new FormConfig($formName, $formConfig, $this->config);


### PR DESCRIPTION
This PR makes it so you can omit `options:` in fields, if you wish:

```
    fields:
        name:
            type: text
        email:
            type: email
            options:
                required: true
                label: Email address
                attr:
                    placeholder: Your email...
                constraints: [ NotBlank, Email ]
        submit:
            type: submit
```

Without this, you'd get a notice exception: 

![screen shot 2017-10-30 at 15 30 07](https://user-images.githubusercontent.com/1833361/32176192-4170b830-bd87-11e7-9caa-250ffce519e5.png)


