### PR TITLE
Add type: markup to boltforms

### DIFF
--- a/config/config.yml.dist
+++ b/config/config.yml.dist
@@ -327,6 +327,13 @@ contact:
 #            options:
 #                required: false
 #                label: Picture of your pet that you want us to add to our site
+#
+#        markup1:
+#            type: markup
+#            options:
+#                label: false
+#                attr:
+#                    value: "<hr><div><p>This will not create a form element.. it will only show you whatever is in the 'value' of this field.</p></div>"
 #        submit:
 #            type: submit
 #            options:

--- a/src/Form/BoltFormsExtension.php
+++ b/src/Form/BoltFormsExtension.php
@@ -44,7 +44,8 @@ class BoltFormsExtension extends AbstractExtension
     protected function loadTypes()
     {
         return [
-            new Type\BoltFormType($this->app['dispatcher'], $this->app['boltforms.config']),
+          new Type\MarkupType(),
+          new Type\BoltFormType($this->app['dispatcher'], $this->app['boltforms.config']),
         ];
     }
 

--- a/src/Form/Type/MarkupType.php
+++ b/src/Form/Type/MarkupType.php
@@ -1,0 +1,43 @@
+<?php
+
+/*
+ * This file adds a MArkup type field to the bolrforms extension
+ */
+
+namespace Bolt\Extension\Bolt\BoltForms\Form\Type;
+
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+class MarkupType extends AbstractType
+{
+  /**
+   * {@inheritdoc}
+   */
+  public function configureOptions(OptionsResolver $resolver)
+  {
+    $resolver->setDefaults(array(
+      // hidden fields cannot have a required attribute
+      'required' => false,
+      // Pass errors to the parent
+      'error_bubbling' => true,
+      'compound' => false,
+    ));
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getName()
+  {
+    return $this->getBlockPrefix();
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getBlockPrefix()
+  {
+    return 'markup';
+  }
+}

--- a/templates/form/_form_theme.twig
+++ b/templates/form/_form_theme.twig
@@ -12,6 +12,11 @@
     {%- endif -%}
 {%- endblock form_widget_simple -%}
 
+{%- block markup_widget -%}
+    {%- set type = type|default('text') -%}
+    {{ attr.value|raw }}
+{%- endblock markup_widget -%}
+
 {# Misc #}
 
 {%- block form_errors -%}


### PR DESCRIPTION
This is a part of a solution for https://github.com/bolt/boltforms/issues/205

With this change you can use `type: markup` fields in your boltforms.yml

```yml
contact:
    submission:
        ajax: false                   # Use AJAX for form submission and handling
    notification:
        enabled: true
        debug: false
        debug_address: name@example.com # Email address used when debug mode is enabled
        debug_smtp: true
        subject: Your message was submitted
        from_name: name                 # Email addresses and names can be either the
        from_email: email               # name of a field below or valid text.
        replyto_email: email            #
        replyto_name: name              # NOTE: Email addresses must be valid
        to_name: My Site                #
        to_email: noreply@example.com   #
    feedback:
        success: Message submission successful
        error: There are errors in the form, please fix before trying to resubmit
    fields:
        name:
            type: text
            options:
                required: true
                label: Name
                attr:
                    placeholder: Your name...
                constraints: [ NotBlank, { Length: { 'min': 3, 'max': 128 } } ]
        email:
            type: email
            options:
                required: true
                label: Email address
                attr:
                    placeholder: Your email...
                constraints: [ NotBlank, Email ]
        markup1:
            type: markup
            options:
                label: false
                attr:
                    value: "<hr><div><p>This will not create a form element.. it will only show you whatever is in the 'value' of this field.</p></div>"
        message:
            type: textarea
            options:
                required: true
                label: Your message
                attr:
                    placeholder: Your message...
                    class: myclass
        needreply:
            type: choice
            options:
                required: false
                label: Do you want us to contact you back?
                choices: { 'Yes': 'yes', 'No': 'no' }
                multiple: false
        submit:
            type: submit
            options:
                label: Submit my message »
                attr:
                    class: button primary
```

It is probable that there is a much cleaner way to add this, but this would be a start.