### PR TITLE
Expanded and custom _form_theme.twig + prefix postfix

### DIFF
--- a/config/config.yml.dist
+++ b/config/config.yml.dist
@@ -202,6 +202,8 @@ contact:
 #                label: Subject of your message
 #                attr:
 #                    placeholder: Just a quick message...
+#                    prefix: '<p>A small HTML prefix</p>'
+#                    postfix: '<p>A small HTML postfix</p>'
 #                constraints: [ NotBlank, {Length: {'min': 3, 'max': 30}} ]
 #        name:
 #            type: text

--- a/docs/fields.md
+++ b/docs/fields.md
@@ -14,8 +14,28 @@ See [the Symfony documentation][forms] for more information.
             label: My Field
             attr:
                 placeholder: Enter some details…
-                class: my-css-class
             constraints: [ NotBlank, {Length: {'min': 3, 'max': 64}} ]
+```
+
+Extra attributes
+----------------
+
+You may use some extra attributes to add a _prefix_ or a _postfix_ to a field. 
+These two attributes will be displayed before and after the form widget
+
+Other attributes, like _data-example_ will be added to the input element.
+You may use these to add aria roles, data attributes and other custom elements.
+
+```yaml
+    field_name:
+        type: field_type
+        required: true|false
+        options:
+            label: My Field
+            attr:
+                data-example: example-value
+                prefix: '<p>A small HTML prefix</p>'
+                postfix: '<p>A small HTML postfix</p>'
 ```
 
 Field(s) default values

--- a/docs/templates.md
+++ b/docs/templates.md
@@ -18,10 +18,11 @@ e.g.:
 
 ```yaml
     templates:
-        form:    my_sub_directory/form.twig
-        email:   my_sub_directory/email.twig
-        subject: my_sub_directory/subject.twig
-        files:   my_sub_directory/file_browser.twig
+        form:       my_sub_directory/form.twig
+        email:      my_sub_directory/email.twig
+        subject:    my_sub_directory/subject.twig
+        files:      my_sub_directory/file_browser.twig
+        form_theme: my_sub_directory/_form_theme.twig
 ```
 
 Default data

--- a/templates/form/_form_theme.twig
+++ b/templates/form/_form_theme.twig
@@ -297,7 +297,7 @@
 {%- endblock repeated_row -%}
 
 {%- block form_row -%}
-    <div>
+    <div>aaa
         {{- form_label(form) -}}
         {{- form_errors(form) -}}
         {{- form_widget(form) -}}
@@ -403,7 +403,9 @@
 {% block attributes -%}
     {%- for attrname, attrvalue in attr -%}
         {{- " " -}}
-        {%- if attrname in ['placeholder', 'title'] -%}
+        {%- if attrname in ['prefix', 'suffix'] -%}
+            {# nope nope nope, these are reserved #}
+        {%- elseif attrname in ['placeholder', 'title'] -%}
             {{- attrname }}="{{ translation_domain is same as(false) ? attrvalue : attrvalue|trans({}, translation_domain) }}"
         {%- elseif attrvalue is same as(true) -%}
             {{- attrname }}="{{ attrname }}"

--- a/templates/form/_form_theme.twig
+++ b/templates/form/_form_theme.twig
@@ -403,7 +403,7 @@
 {% block attributes -%}
     {%- for attrname, attrvalue in attr -%}
         {{- " " -}}
-        {%- if attrname in ['prefix', 'suffix'] -%}
+        {%- if attrname in ['prefix', 'postfix'] -%}
             {# nope nope nope, these are reserved #}
         {%- elseif attrname in ['placeholder', 'title'] -%}
             {{- attrname }}="{{ translation_domain is same as(false) ? attrvalue : attrvalue|trans({}, translation_domain) }}"

--- a/templates/form/_form_theme.twig
+++ b/templates/form/_form_theme.twig
@@ -13,10 +13,7 @@
     {%- if type != 'file' -%}
         <input type="{{ type }}" {{ block('widget_attributes') }} {% if value is not empty %}value="{{ value }}" {% endif %}/>
     {%- else -%}
-        {%- set html_id = 'handleFiles(this.files, "boltforms_preview_' ~ id ~ '")' -%}
-        {%- set attr = attr|merge({'onChange': html_id}) -%}
-        <input type="{{ type }}" {{ block('widget_attributes') }} {% if value is not empty %}value="{{ value }}" {% endif %}/>
-        <div class="boltforms-preview" id="boltforms_preview_{{ id }}"></div>
+        {{- block('file_upload_widget') -}}
     {%- endif -%}
 {%- endblock form_widget_simple -%}
 
@@ -98,6 +95,13 @@
 {%- block radio_widget -%}
     <input type="radio" {{ block('widget_attributes') }}{% if value is defined %} value="{{ value }}"{% endif %}{% if checked %} checked="checked"{% endif %} />
 {%- endblock radio_widget -%}
+
+{%- block file_upload_widget -%}
+    {%- set html_id = 'handleFiles(this.files, "boltforms_preview_' ~ id ~ '")' -%}
+    {%- set attr = attr|merge({'onChange': html_id}) -%}
+    <input type="{{ type }}" {{ block('widget_attributes') }} {% if value is not empty %}value="{{ value }}" {% endif %}/>
+    <div class="boltforms-preview" id="boltforms_preview_{{ id }}"></div>
+{%- endblock file_upload_widget -%}
 
 {%- block datetime_widget -%}
     {% if widget == 'single_text' %}

--- a/templates/form/_form_theme.twig
+++ b/templates/form/_form_theme.twig
@@ -1,12 +1,18 @@
-{# Widgets #}
+{#
+How to customize the theme
 
-{%- block form_widget -%}
-    {% if compound %}
-        {{- block('form_widget_compound') -}}
-    {% else %}
-        {{- block('form_widget_simple') -}}
-    {% endif %}
-{%- endblock form_widget -%}
+Copy this file to the assets folder in your theme and:
+- add the following key to your global boltforms config
+or
+- add the following key to the templates section for a single form
+
+--
+templates:
+   formtheme: assets/_form_theme.twig
+--
+#}
+
+{# Widgets #}
 
 {%- block form_widget_simple -%}
     {%- set type = type|default('text') -%}
@@ -27,24 +33,9 @@
     </div>
 {%- endblock form_widget_compound -%}
 
-{%- block collection_widget -%}
-    {% if prototype is defined %}
-        {%- set attr = attr|merge({'data-prototype': form_row(prototype) }) -%}
-    {% endif %}
-    {{- block('form_widget') -}}
-{%- endblock collection_widget -%}
-
 {%- block textarea_widget -%}
     <textarea {{ block('widget_attributes') }}>{{ value }}</textarea>
 {%- endblock textarea_widget -%}
-
-{%- block choice_widget -%}
-    {% if expanded %}
-        {{- block('choice_widget_expanded') -}}
-    {% else %}
-        {{- block('choice_widget_collapsed') -}}
-    {% endif %}
-{%- endblock choice_widget -%}
 
 {%- block choice_widget_expanded -%}
     <div {{ block('widget_container_attributes') }}>
@@ -297,7 +288,7 @@
 {%- endblock repeated_row -%}
 
 {%- block form_row -%}
-    <div>aaa
+    <div>
         {{- form_label(form) -}}
         {{- form_errors(form) -}}
         {{- form_widget(form) -}}
@@ -415,3 +406,28 @@
     {%- endfor -%}
 {%- endblock attributes -%}
 
+{# System Widgets #}
+{# These widgets are ususally not changed #}
+
+{%- block form_widget -%}
+    {% if compound %}
+        {{- block('form_widget_compound') -}}
+    {% else %}
+        {{- block('form_widget_simple') -}}
+    {% endif %}
+{%- endblock form_widget -%}
+
+{%- block collection_widget -%}
+    {% if prototype is defined %}
+        {%- set attr = attr|merge({'data-prototype': form_row(prototype) }) -%}
+    {% endif %}
+    {{- block('form_widget') -}}
+{%- endblock collection_widget -%}
+
+{%- block choice_widget -%}
+    {% if expanded %}
+        {{- block('choice_widget_expanded') -}}
+    {% else %}
+        {{- block('choice_widget_collapsed') -}}
+    {% endif %}
+{%- endblock choice_widget -%}

--- a/templates/form/_form_theme.twig
+++ b/templates/form/_form_theme.twig
@@ -1,5 +1,13 @@
 {# Widgets #}
 
+{%- block form_widget -%}
+    {% if compound %}
+        {{- block('form_widget_compound') -}}
+    {% else %}
+        {{- block('form_widget_simple') -}}
+    {% endif %}
+{%- endblock form_widget -%}
+
 {%- block form_widget_simple -%}
     {%- set type = type|default('text') -%}
     {%- if type != 'file' -%}
@@ -12,7 +20,324 @@
     {%- endif -%}
 {%- endblock form_widget_simple -%}
 
+{%- block form_widget_compound -%}
+    <div {{ block('widget_container_attributes') }}>
+        {%- if form is rootform -%}
+            {{ form_errors(form) }}
+        {%- endif -%}
+        {{- block('form_rows') -}}
+        {{- form_rest(form) -}}
+    </div>
+{%- endblock form_widget_compound -%}
+
+{%- block collection_widget -%}
+    {% if prototype is defined %}
+        {%- set attr = attr|merge({'data-prototype': form_row(prototype) }) -%}
+    {% endif %}
+    {{- block('form_widget') -}}
+{%- endblock collection_widget -%}
+
+{%- block textarea_widget -%}
+    <textarea {{ block('widget_attributes') }}>{{ value }}</textarea>
+{%- endblock textarea_widget -%}
+
+{%- block choice_widget -%}
+    {% if expanded %}
+        {{- block('choice_widget_expanded') -}}
+    {% else %}
+        {{- block('choice_widget_collapsed') -}}
+    {% endif %}
+{%- endblock choice_widget -%}
+
+{%- block choice_widget_expanded -%}
+    <div {{ block('widget_container_attributes') }}>
+    {%- for child in form %}
+        {{- form_widget(child) -}}
+        {{- form_label(child, null, {translation_domain: choice_translation_domain}) -}}
+    {% endfor -%}
+    </div>
+{%- endblock choice_widget_expanded -%}
+
+{%- block choice_widget_collapsed -%}
+    {%- if required and placeholder is none and not placeholder_in_choices and not multiple and (attr.size is not defined or attr.size <= 1) -%}
+        {% set required = false %}
+    {%- endif -%}
+    <select {{ block('widget_attributes') }}{% if multiple %} multiple="multiple"{% endif %}>
+        {%- if placeholder is not none -%}
+            <option value=""{% if required and value is empty %} selected="selected"{% endif %}>{{ placeholder != '' ? (translation_domain is same as(false) ? placeholder : placeholder|trans({}, translation_domain)) }}</option>
+        {%- endif -%}
+        {%- if preferred_choices|length > 0 -%}
+            {% set options = preferred_choices %}
+            {{- block('choice_widget_options') -}}
+            {%- if choices|length > 0 and separator is not none -%}
+                <option disabled="disabled">{{ separator }}</option>
+            {%- endif -%}
+        {%- endif -%}
+        {%- set options = choices -%}
+        {{- block('choice_widget_options') -}}
+    </select>
+{%- endblock choice_widget_collapsed -%}
+
+{%- block choice_widget_options -%}
+    {% for group_label, choice in options %}
+        {%- if choice is iterable -%}
+            <optgroup label="{{ choice_translation_domain is same as(false) ? group_label : group_label|trans({}, choice_translation_domain) }}">
+                {% set options = choice %}
+                {{- block('choice_widget_options') -}}
+            </optgroup>
+        {%- else -%}
+            <option value="{{ choice.value }}"{% if choice.attr %}{% with { attr: choice.attr } %}{{ block('attributes') }}{% endwith %}{% endif %}{% if choice is selectedchoice(value) %} selected="selected"{% endif %}>{{ choice_translation_domain is same as(false) ? choice.label : choice.label|trans({}, choice_translation_domain) }}</option>
+        {%- endif -%}
+    {% endfor %}
+{%- endblock choice_widget_options -%}
+
+{%- block checkbox_widget -%}
+    <input type="checkbox" {{ block('widget_attributes') }}{% if value is defined %} value="{{ value }}"{% endif %}{% if checked %} checked="checked"{% endif %} />
+{%- endblock checkbox_widget -%}
+
+{%- block radio_widget -%}
+    <input type="radio" {{ block('widget_attributes') }}{% if value is defined %} value="{{ value }}"{% endif %}{% if checked %} checked="checked"{% endif %} />
+{%- endblock radio_widget -%}
+
+{%- block datetime_widget -%}
+    {% if widget == 'single_text' %}
+        {{- block('form_widget_simple') -}}
+    {%- else -%}
+        <div {{ block('widget_container_attributes') }}>
+            {{- form_errors(form.date) -}}
+            {{- form_errors(form.time) -}}
+            {{- form_widget(form.date) -}}
+            {{- form_widget(form.time) -}}
+        </div>
+    {%- endif -%}
+{%- endblock datetime_widget -%}
+
+{%- block date_widget -%}
+    {%- if widget == 'single_text' -%}
+        {{ block('form_widget_simple') }}
+    {%- else -%}
+        <div {{ block('widget_container_attributes') }}>
+            {{- date_pattern|replace({
+                '{{ year }}':  form_widget(form.year),
+                '{{ month }}': form_widget(form.month),
+                '{{ day }}':   form_widget(form.day),
+            })|raw -}}
+        </div>
+    {%- endif -%}
+{%- endblock date_widget -%}
+
+{%- block time_widget -%}
+    {%- if widget == 'single_text' -%}
+        {{ block('form_widget_simple') }}
+    {%- else -%}
+        {%- set vars = widget == 'text' ? { 'attr': { 'size': 1 }} : {} -%}
+        <div {{ block('widget_container_attributes') }}>
+            {{ form_widget(form.hour, vars) }}{% if with_minutes %}:{{ form_widget(form.minute, vars) }}{% endif %}{% if with_seconds %}:{{ form_widget(form.second, vars) }}{% endif %}
+        </div>
+    {%- endif -%}
+{%- endblock time_widget -%}
+
+{%- block dateinterval_widget -%}
+    {%- if widget == 'single_text' -%}
+        {{- block('form_widget_simple') -}}
+    {%- else -%}
+        <div {{ block('widget_container_attributes') }}>
+            {{- form_errors(form) -}}
+            <table class="{{ table_class|default('') }}">
+                <thead>
+                    <tr>
+                        {%- if with_years %}<th>{{ form_label(form.years) }}</th>{% endif -%}
+                        {%- if with_months %}<th>{{ form_label(form.months) }}</th>{% endif -%}
+                        {%- if with_weeks %}<th>{{ form_label(form.weeks) }}</th>{% endif -%}
+                        {%- if with_days %}<th>{{ form_label(form.days) }}</th>{% endif -%}
+                        {%- if with_hours %}<th>{{ form_label(form.hours) }}</th>{% endif -%}
+                        {%- if with_minutes %}<th>{{ form_label(form.minutes) }}</th>{% endif -%}
+                        {%- if with_seconds %}<th>{{ form_label(form.seconds) }}</th>{% endif -%}
+                    </tr>
+                </thead>
+                <tbody>
+                    <tr>
+                        {%- if with_years %}<td>{{ form_widget(form.years) }}</td>{% endif -%}
+                        {%- if with_months %}<td>{{ form_widget(form.months) }}</td>{% endif -%}
+                        {%- if with_weeks %}<td>{{ form_widget(form.weeks) }}</td>{% endif -%}
+                        {%- if with_days %}<td>{{ form_widget(form.days) }}</td>{% endif -%}
+                        {%- if with_hours %}<td>{{ form_widget(form.hours) }}</td>{% endif -%}
+                        {%- if with_minutes %}<td>{{ form_widget(form.minutes) }}</td>{% endif -%}
+                        {%- if with_seconds %}<td>{{ form_widget(form.seconds) }}</td>{% endif -%}
+                    </tr>
+                </tbody>
+            </table>
+            {%- if with_invert %}{{ form_widget(form.invert) }}{% endif -%}
+        </div>
+    {%- endif -%}
+{%- endblock dateinterval_widget -%}
+
+{%- block number_widget -%}
+    {# type="number" doesn't work with floats #}
+    {%- set type = type|default('text') -%}
+    {{ block('form_widget_simple') }}
+{%- endblock number_widget -%}
+
+{%- block integer_widget -%}
+    {%- set type = type|default('number') -%}
+    {{ block('form_widget_simple') }}
+{%- endblock integer_widget -%}
+
+{%- block money_widget -%}
+    {{ money_pattern|replace({ '{{ widget }}': block('form_widget_simple') })|raw }}
+{%- endblock money_widget -%}
+
+{%- block url_widget -%}
+    {%- set type = type|default('url') -%}
+    {{ block('form_widget_simple') }}
+{%- endblock url_widget -%}
+
+{%- block search_widget -%}
+    {%- set type = type|default('search') -%}
+    {{ block('form_widget_simple') }}
+{%- endblock search_widget -%}
+
+{%- block percent_widget -%}
+    {%- set type = type|default('text') -%}
+    {{ block('form_widget_simple') }} %
+{%- endblock percent_widget -%}
+
+{%- block password_widget -%}
+    {%- set type = type|default('password') -%}
+    {{ block('form_widget_simple') }}
+{%- endblock password_widget -%}
+
+{%- block hidden_widget -%}
+    {%- set type = type|default('hidden') -%}
+    {{ block('form_widget_simple') }}
+{%- endblock hidden_widget -%}
+
+{%- block email_widget -%}
+    {%- set type = type|default('email') -%}
+    {{ block('form_widget_simple') }}
+{%- endblock email_widget -%}
+
+{%- block range_widget -%}
+    {% set type = type|default('range') %}
+    {{- block('form_widget_simple') -}}
+{%- endblock range_widget %}
+
+{%- block button_widget -%}
+    {%- if label is not same as(false) and label is empty -%}
+        {%- if label_format is not empty -%}
+            {% set label = label_format|replace({
+                '%name%': name,
+                '%id%': id,
+            }) %}
+        {%- else -%}
+            {% set label = name|humanize %}
+        {%- endif -%}
+    {%- endif -%}
+    <button type="{{ type|default('button') }}" {{ block('button_attributes') }}>{{ translation_domain is same as(false) ? label : label|trans({}, translation_domain) }}</button>
+{%- endblock button_widget -%}
+
+{%- block submit_widget -%}
+    {%- set type = type|default('submit') -%}
+    {{ block('button_widget') }}
+{%- endblock submit_widget -%}
+
+{%- block reset_widget -%}
+    {%- set type = type|default('reset') -%}
+    {{ block('button_widget') }}
+{%- endblock reset_widget -%}
+
+{%- block tel_widget -%}
+    {%- set type = type|default('tel') -%}
+    {{ block('form_widget_simple') }}
+{%- endblock tel_widget -%}
+
+{%- block color_widget -%}
+    {%- set type = type|default('color') -%}
+    {{ block('form_widget_simple') }}
+{%- endblock color_widget -%}
+
+{# Labels #}
+
+{%- block form_label -%}
+    {% if label is not same as(false) -%}
+        {% if not compound -%}
+            {% set label_attr = label_attr|merge({'for': id}) %}
+        {%- endif -%}
+        {% if required -%}
+            {% set label_attr = label_attr|merge({'class': (label_attr.class|default('') ~ ' required')|trim}) %}
+        {%- endif -%}
+        {% if label is empty -%}
+            {%- if label_format is not empty -%}
+                {% set label = label_format|replace({
+                    '%name%': name,
+                    '%id%': id,
+                }) %}
+            {%- else -%}
+                {% set label = name|humanize %}
+            {%- endif -%}
+        {%- endif -%}
+        <{{ element|default('label') }}{% if label_attr %}{% with { attr: label_attr } %}{{ block('attributes') }}{% endwith %}{% endif %}>{{ translation_domain is same as(false) ? label : label|trans({}, translation_domain) }}</{{ element|default('label') }}>
+    {%- endif -%}
+{%- endblock form_label -%}
+
+{%- block button_label -%}{%- endblock -%}
+
+{# Rows #}
+
+{%- block repeated_row -%}
+    {#
+    No need to render the errors here, as all errors are mapped
+    to the first child (see RepeatedTypeValidatorExtension).
+    #}
+    {{- block('form_rows') -}}
+{%- endblock repeated_row -%}
+
+{%- block form_row -%}
+    <div>
+        {{- form_label(form) -}}
+        {{- form_errors(form) -}}
+        {{- form_widget(form) -}}
+    </div>
+{%- endblock form_row -%}
+
+{%- block button_row -%}
+    <div>
+        {{- form_widget(form) -}}
+    </div>
+{%- endblock button_row -%}
+
+{%- block hidden_row -%}
+    {{ form_widget(form) }}
+{%- endblock hidden_row -%}
+
 {# Misc #}
+
+{%- block form -%}
+    {{ form_start(form) }}
+        {{- form_widget(form) -}}
+    {{ form_end(form) }}
+{%- endblock form -%}
+
+{%- block form_start -%}
+    {%- do form.setMethodRendered() -%}
+    {% set method = method|upper %}
+    {%- if method in ["GET", "POST"] -%}
+        {% set form_method = method %}
+    {%- else -%}
+        {% set form_method = "POST" %}
+    {%- endif -%}
+    <form name="{{ name }}" method="{{ form_method|lower }}"{% if action != '' %} action="{{ action }}"{% endif %}{% for attrname, attrvalue in attr %} {{ attrname }}="{{ attrvalue }}"{% endfor %}{% if multipart %} enctype="multipart/form-data"{% endif %}>
+    {%- if form_method != method -%}
+        <input type="hidden" name="_method" value="{{ method }}" />
+    {%- endif -%}
+{%- endblock form_start -%}
+
+{%- block form_end -%}
+    {%- if not render_rest is defined or render_rest -%}
+        {{ form_rest(form) }}
+    {%- endif -%}
+    </form>
+{%- endblock form_end -%}
 
 {%- block form_errors -%}
     {%- if errors|length > 0 -%}
@@ -23,3 +348,64 @@
         </ul>
     {%- endif -%}
 {%- endblock form_errors -%}
+
+{%- block form_rest -%}
+    {% for child in form -%}
+        {% if not child.rendered %}
+            {{- form_row(child) -}}
+        {% endif %}
+    {%- endfor -%}
+
+    {% if not form.methodRendered and form is rootform %}
+        {%- do form.setMethodRendered() -%}
+        {% set method = method|upper %}
+        {%- if method in ["GET", "POST"] -%}
+            {% set form_method = method %}
+        {%- else -%}
+            {% set form_method = "POST" %}
+        {%- endif -%}
+
+        {%- if form_method != method -%}
+            <input type="hidden" name="_method" value="{{ method }}" />
+        {%- endif -%}
+    {% endif -%}
+{% endblock form_rest %}
+
+{# Support #}
+
+{%- block form_rows -%}
+    {% for child in form %}
+        {{- form_row(child) -}}
+    {% endfor %}
+{%- endblock form_rows -%}
+
+{%- block widget_attributes -%}
+    id="{{ id }}" name="{{ full_name }}"
+    {%- if disabled %} disabled="disabled"{% endif -%}
+    {%- if required %} required="required"{% endif -%}
+    {{ block('attributes') }}
+{%- endblock widget_attributes -%}
+
+{%- block widget_container_attributes -%}
+    {%- if id is not empty %}id="{{ id }}"{% endif -%}
+    {{ block('attributes') }}
+{%- endblock widget_container_attributes -%}
+
+{%- block button_attributes -%}
+    id="{{ id }}" name="{{ full_name }}"{% if disabled %} disabled="disabled"{% endif -%}
+    {{ block('attributes') }}
+{%- endblock button_attributes -%}
+
+{% block attributes -%}
+    {%- for attrname, attrvalue in attr -%}
+        {{- " " -}}
+        {%- if attrname in ['placeholder', 'title'] -%}
+            {{- attrname }}="{{ translation_domain is same as(false) ? attrvalue : attrvalue|trans({}, translation_domain) }}"
+        {%- elseif attrvalue is same as(true) -%}
+            {{- attrname }}="{{ attrname }}"
+        {%- elseif attrvalue is not same as(false) -%}
+            {{- attrname }}="{{ attrvalue }}"
+        {%- endif -%}
+    {%- endfor -%}
+{%- endblock attributes -%}
+

--- a/templates/form/form.twig
+++ b/templates/form/form.twig
@@ -56,8 +56,8 @@
                             <span class="boltforms-error">{{ form_errors(form[key]) }}</span>
                             <span class="boltforms-value">{{ form_widget(form[key]) }}</span>
                         </div>
-                        {% if form[key].vars.attr.suffix is defined %}
-                            {{ form[key].vars.attr.suffix|raw }}
+                        {% if form[key].vars.attr.postfix is defined %}
+                            {{ form[key].vars.attr.postfix|raw }}
                         {% endif %}
                     {% endif %}
                 {% endfor %}
@@ -87,8 +87,8 @@
                                 {{ form_widget(form[key]) }}
                             {% endif %}
                         </div>
-                        {% if form[key].vars.attr.suffix is defined %}
-                            {{ form[key].vars.attr.suffix|raw }}
+                        {% if form[key].vars.attr.postfix is defined %}
+                            {{ form[key].vars.attr.postfix|raw }}
                         {% endif %}
                     {% endif %}
                 {% endfor %}

--- a/templates/form/form.twig
+++ b/templates/form/form.twig
@@ -48,19 +48,27 @@
             {% block boltforms_form_fields %}
                 {% for key, value in fields  %}
                     {% if value.config.type.name != 'submit' %}
+                        {% if form[key].vars.attr.prefix is defined %}
+                            {{ form[key].vars.attr.prefix|raw }}
+                        {% endif %}
                         <div class="boltforms-row{% if form[key].vars.attr.class is defined %} boltforms-{{ form[key].vars.attr.class }}-row{% endif %}">
                             <span class="boltforms-label">{{ form_label(form[key]) }}</span>
                             <span class="boltforms-error">{{ form_errors(form[key]) }}</span>
                             <span class="boltforms-value">{{ form_widget(form[key]) }}</span>
                         </div>
+                        {% if form[key].vars.attr.suffix is defined %}
+                            {{ form[key].vars.attr.suffix|raw }}
+                        {% endif %}
                     {% endif %}
                 {% endfor %}
 
                 {{ spambot.recaptcha(recaptcha) }}
 
-                <br>
                 {% for key, value in fields  %}
                     {% if value.config.type.name == 'submit' %}
+                        {% if form[key].vars.attr.prefix is defined %}
+                            {{ form[key].vars.attr.prefix|raw }}
+                        {% endif %}
                         <div class="boltforms-row{% if form[key].vars.attr.class is defined %} boltforms-{{ form[key].vars.attr.class }}-row{% endif %}">
                             {% if recaptcha.type == 'invisible' and recaptcha.enabled %}
                                 {{ form_widget(
@@ -79,6 +87,9 @@
                                 {{ form_widget(form[key]) }}
                             {% endif %}
                         </div>
+                        {% if form[key].vars.attr.suffix is defined %}
+                            {{ form[key].vars.attr.suffix|raw }}
+                        {% endif %}
                     {% endif %}
                 {% endfor %}
             {% endblock boltforms_form_fields %}


### PR DESCRIPTION
This is a followup of #205 and #216 - it does not add a markup field, but it adds prefix and postfix fields.

As discussed with @bobdenotter  I've added the blocks from the [twig bridge](https://github.com/symfony/symfony/blob/master/src/Symfony/Bridge/Twig/Resources/views/Form/form_div_layout.html.twig) to `_form_theme.twig` so there are no inherited blocks hidden far away from the extension anymore.

I've also added hints to the documentation and to `_form_theme.twig` itself about how you can/should override it.

This will make it easier for front end developers to make use of the custom themes now.

In an additional change, the `prefix` and `postfix` attributes will be hidden in the attributes on the form elements itself, and will instead be prefixed and postfixed to the form row. 

With these attributes extra information surrounding form elements can be added. It also enables grouping elements in fieldsets by using the following `prefix: '<fieldset><legend>This is my fieldset</legend>'` and `postfix: '</fieldset>'`

The separation of concerns in the ` .yml` is broken with the prefix and postfix attributes, for the reasons stated in #216.





