### PR TITLE
Fix for dynamic data events

### DIFF
--- a/src/Config/Form/FieldBag.php
+++ b/src/Config/Form/FieldBag.php
@@ -43,6 +43,9 @@ class FieldBag extends ParameterBag
         $this->fieldName = $fieldName;
         $parameters += ['type' => null, 'options' => null];
         $parameters['options'] = new FieldOptionsBag($parameters['options']);
+        if (isset($parameters['event'])) {
+            $parameters['event'] = new FieldOptionsBag($parameters['event']);
+        }
 
         parent::__construct($parameters);
     }

--- a/src/Event/CustomDataEvent.php
+++ b/src/Event/CustomDataEvent.php
@@ -4,6 +4,7 @@ namespace Bolt\Extension\Bolt\BoltForms\Event;
 
 use Bolt\Extension\Bolt\BoltForms\Config\Form\FieldOptionsBag;
 use Symfony\Component\EventDispatcher\Event;
+use Symfony\Component\HttpFoundation\ParameterBag;
 
 /**
  * Custom data event interface for BoltForms
@@ -38,10 +39,10 @@ class CustomDataEvent extends Event
     protected $data;
 
     /**
-     * @param string          $eventName
-     * @param FieldOptionsBag $eventParams
+     * @param string $eventName
+     * @param ParameterBag $eventParams
      */
-    public function __construct($eventName, FieldOptionsBag $eventParams)
+    public function __construct($eventName, ParameterBag $eventParams)
     {
         $this->eventName = $eventName;
         $this->eventParams = $eventParams;

--- a/src/Event/CustomDataEvent.php
+++ b/src/Event/CustomDataEvent.php
@@ -2,7 +2,6 @@
 
 namespace Bolt\Extension\Bolt\BoltForms\Event;
 
-use Bolt\Extension\Bolt\BoltForms\Config\Form\FieldOptionsBag;
 use Symfony\Component\EventDispatcher\Event;
 use Symfony\Component\HttpFoundation\ParameterBag;
 
@@ -33,7 +32,7 @@ class CustomDataEvent extends Event
 {
     /** @var string */
     protected $eventName;
-    /** @var FieldOptionsBag */
+    /** @var ParameterBag */
     protected $eventParams;
     /** @var mixed */
     protected $data;
@@ -61,7 +60,7 @@ class CustomDataEvent extends Event
     /**
      * Get the user supplied parameters.
      *
-     * @return FieldOptionsBag
+     * @return ParameterBag
      */
     public function getParameters()
     {

--- a/src/Submission/Processor/Fields.php
+++ b/src/Submission/Processor/Fields.php
@@ -62,30 +62,19 @@ class Fields extends AbstractProcessor
         $formConfig = $lifeEvent->getFormConfig();
         $formData = $lifeEvent->getFormData();
 
-        foreach ($formData->toArray() as $fieldName => $fieldValue) {
+        foreach ($formConfig->getFields() as $fieldName => $fieldConf) {
             /** @var \Bolt\Extension\Bolt\BoltForms\Config\Form\FieldBag $fieldConf */
-            $fieldConf = $formConfig->getFields()->get($fieldName);
-            if ($fieldConf === null && $this->config->isDebug()) {
-                //$message = sprintf(
-//    'Attempted to use an invalid field name "%s" on the form "%s". Available fields are: %s',
-//    $fieldName,
-//    $formConfig->getName(),
-//    implode(', ', $formConfig->getFields()->keys())
-//);
-//throw new FormOption\Exception($message);
-            }
             if ($fieldConf === null) {
                 continue;
             }
 
             /** @var \Bolt\Extension\Bolt\BoltForms\Config\Form\FieldOptionsBag $fieldOptions */
-            $fieldOptions = $fieldConf->getOptions();
-            if ($fieldOptions->has('event') === false) {
+            if ($fieldConf->has('event') === false) {
                 continue;
             }
 
             // Handle events for custom data
-            $eventConfig = $fieldOptions->get('event');
+            $eventConfig = $fieldConf->get('event');
             if ($eventConfig->has('name')) {
                 $data = $this->dispatchCustomDataEvent($dispatcher, $eventConfig);
                 $formData->set($fieldName, $data);


### PR DESCRIPTION
This tidies up a few structural problems with the handling of dynamic data events.

Firstly the loop now iterates all fields, not just submitted ones, previously a hidden field without a default value would not be processed because it would evaluate to null.

Secondly the code was looking for the event config inside the options array which is incorrect as per the docs.