### PR TITLE
remove classmap from json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -37,10 +37,7 @@
             "Bolt\\Extension\\Bolt\\BoltForms\\": [
                 "src/"
             ]
-        },
-        "classmap": [
-            "doc/example/"
-        ]
+        }
     },
     "autoload-dev": {
         "psr-4": {


### PR DESCRIPTION
The classmap was removed, but composer was still looking for it - which resulted in errors for composer updates and installs