### PR TITLE
Add form data to email config

### DIFF
--- a/src/Config/EmailConfig.php
+++ b/src/Config/EmailConfig.php
@@ -322,7 +322,9 @@ class EmailConfig extends ParameterBag
             if (is_array($key)) {
                 $value = [];
                 foreach($key as $keyPart) {
-                    $value[] = $this->getConfigValue($formData, $keyPart);
+                    if ($this->getConfigValue($formData, $keyPart) != $keyPart) {
+                        $value[] = $this->getConfigValue($formData, $keyPart);
+                    }
                 }
                 $value = implode(" ", $value);
             } else {


### PR DESCRIPTION
Fixes #237.

This prevents BoltForms from adding the placeholder of not filled in unrequired fields in the notification email details .  For instance, set in `boltforms.bolt.yml` like:
`from_name: [ name, no_required_field, last name]`
`replyto_name: [ name, no_required_field, last name]`