### PR TITLE
Add rootform test to extension

### DIFF
--- a/src/Twig/Extension/BoltFormsExtension.php
+++ b/src/Twig/Extension/BoltFormsExtension.php
@@ -3,6 +3,9 @@
 namespace Bolt\Extension\Bolt\BoltForms\Twig\Extension;
 
 use Twig_Extension as Extension;
+use Twig_SimpleFunction;
+use Twig_SimpleTest;
+use Twig_Test;
 
 /**
  * Twig extension for BoltForms
@@ -38,8 +41,19 @@ class BoltFormsExtension extends Extension
         $env  = ['needs_environment' => true];
 
         return [
-            new \Twig_SimpleFunction('boltforms', [BoltFormsRuntime::class, 'twigBoltForms'], $safe + $env),
-            new \Twig_SimpleFunction('boltforms_uploads', [BoltFormsRuntime::class, 'twigBoltFormsUploads']),
+            new Twig_SimpleFunction('boltforms', [BoltFormsRuntime::class, 'twigBoltForms'], $safe + $env),
+            new Twig_SimpleFunction('boltforms_uploads', [BoltFormsRuntime::class, 'twigBoltFormsUploads']),
         ];
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getTests()
+    {
+        return array(
+            new Twig_SimpleTest('rootform', [BoltFormsRuntime::class, 'twigIsRootForm']),
+        );
+    }
+
 }

--- a/src/Twig/Extension/BoltFormsExtension.php
+++ b/src/Twig/Extension/BoltFormsExtension.php
@@ -5,7 +5,6 @@ namespace Bolt\Extension\Bolt\BoltForms\Twig\Extension;
 use Twig_Extension as Extension;
 use Twig_SimpleFunction;
 use Twig_SimpleTest;
-use Twig_Test;
 
 /**
  * Twig extension for BoltForms

--- a/src/Twig/Extension/BoltFormsRuntime.php
+++ b/src/Twig/Extension/BoltFormsRuntime.php
@@ -14,6 +14,7 @@ use Bolt\Extension\Bolt\BoltForms\Submission\Processor;
 use Bolt\Legacy;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\Finder\Finder;
+use Symfony\Component\Form\FormView;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpFoundation\Session\Flash\FlashBagInterface;
@@ -243,6 +244,16 @@ class BoltFormsRuntime
         return new Twig_Markup($html, 'UTF-8');
     }
 
+    /**
+     * Twig test to determine if this is a root form object
+     *
+     * @param FormView $formView
+     * @return bool
+     */
+    public function twigIsRootForm(FormView $formView)
+    {
+        return null === $formView->parent;
+    }
     /**
      * Get the context compiler either from session, or factory.
      *


### PR DESCRIPTION
New templates used a test to determine whether a form element is a root form but this is only defined in the Symfony Twig bridge which by default isn't available in Bolt.

This adds the test explicitly to BoltForms so we can use it in templates.