### PR TITLE
Serialize form data if we are passed a class that can be serialized

### DIFF
--- a/src/Submission/Handler/ContentType.php
+++ b/src/Submission/Handler/ContentType.php
@@ -70,6 +70,13 @@ class ContentType extends AbstractHandler
             }
 
             $fieldName = $fieldMap->get($name);
+
+            // A Catch for uploaded files which present as a serializable instance
+            if (is_subclass_of($data, 'JsonSerializable')) {
+                /** @var \JsonSerializable $data */
+                $data = $data->jsonSerialize();
+            }
+
             $record->set($fieldName, $data);
         }
 


### PR DESCRIPTION
Fixes #248 

This is mainly to handle image uploads since they get to the Contenttype handler as an instance of `Submission\File` rather than an array.

At this point the field save will not work so we can call the `jsonSerialize` method to get the prepared data. Using this approach allows other custom field handlers in the future to do the same if needed.