### PR TITLE
Update debug explanation

### DIFF
--- a/config/config.yml.dist
+++ b/config/config.yml.dist
@@ -6,8 +6,8 @@
 #
 # Global debugging on/off switch
 #
-# If enabled, ALL forms will go into debug mode.  However, when disabled an individual
-# form can still enable it's own debug — specific for and to that form
+# If enabled, ALL forms will go into debug mode.  
+# NOTE, setting the debug on a specific form will override these global settings — specific for and to that form.
 debug:
     enabled: true
     address: noreply@example.com


### PR DESCRIPTION
I _expect_ that a debug set to 'false' for a specific form actually overrides the global settings, when set to 'true'. Couldn't find anything in the docs and the old explanation in config made it not completely clear. 

If this text change does not reflect what actually happens with the overrides, feel free to discard! If it does, this might be clearer.