### PR TITLE
[Hotfix] Make sure response is returned where a refresh is available

### DIFF
--- a/src/Submission/Handler/Redirect.php
+++ b/src/Submission/Handler/Redirect.php
@@ -67,12 +67,13 @@ class Redirect
      * Refresh the current page.
      *
      * @param Request $request
+     * @return RedirectResponse
      */
     public function refresh(Request $request)
     {
         $response = new RedirectResponse($request->getRequestUri());
 
-        $response->send();
+        return $response->send();
     }
 
     /**

--- a/src/Submission/Processor/Redirect.php
+++ b/src/Submission/Processor/Redirect.php
@@ -86,7 +86,11 @@ class Redirect extends AbstractProcessor
 
         // Do a get on the page as it was probably POSTed
         $request = $this->requestStack->getCurrentRequest();
-        $handler->refresh($request);
+
+        $response = $handler->refresh($request);
+        if ($response instanceof RedirectResponse) {
+            return;
+        }
 
         throw new HttpException(Response::HTTP_FOUND, '', null, []);
     }


### PR DESCRIPTION
Fixes #256 

If we have a redirect response we need to return it in the handler, otherwise it passes through to the thrown exception.