### PR TITLE
Exclude handled attributes from the general list in form_start

### DIFF
--- a/templates/form/_form_theme.twig
+++ b/templates/form/_form_theme.twig
@@ -323,7 +323,12 @@ templates:
     {%- else -%}
         {% set form_method = "POST" %}
     {%- endif -%}
-    <form name="{{ name }}" method="{{ form_method|lower }}"{% if action != '' %} action="{{ action }}"{% endif %}{% for attrname, attrvalue in attr %} {{ attrname }}="{{ attrvalue }}"{% endfor %}{% if multipart %} enctype="multipart/form-data"{% endif %}>
+    <form name="{{ name }}"
+        method="{{ form_method|lower }}"
+        {% if action != '' %} action="{{ action }}"{% endif %}
+        {% for attrname, attrvalue in attr if attrname not in ['name', 'method', 'enctype'] %} {{ attrname }}="{{ attrvalue }}"{% endfor %}
+        {% if multipart %} enctype="multipart/form-data"{% endif %}
+    >
     {%- if form_method != method -%}
         <input type="hidden" name="_method" value="{{ method }}" />
     {%- endif -%}


### PR DESCRIPTION
Fixes #269

Excludes the attributes that are already managed from the general attributes list.